### PR TITLE
Require auth token for member code retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Member QR Perks
+
+This project serves QR code-based membership perks through a serverless API and a small embeddable widget.
+
+## Authentication
+
+The `/api/my-codes` endpoint requires an authenticated request. Clients must include a Supabase access token in the `Authorization` header:
+
+```
+Authorization: Bearer <access_token>
+```
+
+Tokens are validated with `supabase.auth.getUser` and must belong to the same email address supplied in the request.
+
+### Widget
+
+The script served at `/public/widget.js` forwards a token with each API call. Provide the token via a `data-token` attribute when embedding the widget:
+
+```html
+<div id="member-qr-widget"></div>
+<script src="/public/widget.js"
+        data-api="/api"
+        data-email="member@example.com"
+        data-token="ACCESS_TOKEN"></script>
+```
+
+The widget uses the token for requests to `/api/my-codes` and displays the member's current perks.

--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
+import { readFile } from "fs/promises";
 
 /** ========= helpers ========= */
 function getSupabase() {
@@ -41,6 +42,17 @@ async function ensureMonthlyCodes(supa, userId, mk) {
 async function apiMyCodes(req, res, supa, url) {
   const email = url.searchParams.get("email");
   if (!email) return res.status(400).json({ error: "missing_email" });
+
+  const auth = req.headers.authorization || "";
+  if (!auth.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "missing_token" });
+  }
+  const token = auth.slice(7);
+  const { data: authData, error: authErr } = await supa.auth.getUser(token);
+  if (authErr || !authData.user || authData.user.email !== email) {
+    return res.status(401).json({ error: "invalid_token" });
+  }
+
   const { data: user } = await supa.from("users").select("*").eq("email", email).single();
   if (!user) return res.status(403).json({ error: "unknown_member" });
   if (user.active_until < todayUtc()) return res.json({ codes: [], reason: "inactive_membership" });
@@ -124,57 +136,10 @@ async function apiRedeem(req, res, supa, body) {
 }
 
 /** ========= static assets served by this same function ========= */
-function serveWidgetJS(res) {
+async function serveWidgetJS(res) {
   res.setHeader("Content-Type", "application/javascript; charset=utf-8");
-  res.end(`(async function(){
-  const el = document.getElementById("member-qr-widget"); if (!el) return;
-  const s = document.currentScript;
-  const API = s.getAttribute("data-api") || (location.origin.replace(/\\/$/,'') + "/api");
-  const BRAND = s.getAttribute("data-brand") || "Your Brand";
-  let email = s.getAttribute("data-email") || "";
-
-  function h(tag, attrs={}, kids=[]) { const e=document.createElement(tag);
-    Object.entries(attrs).forEach(([k,v])=> e.setAttribute(k,v));
-    (Array.isArray(kids)?kids:[kids]).forEach(c=> e.appendChild(typeof c==="string"?document.createTextNode(c):c));
-    return e;
-  }
-  function promptEmail(){ el.innerHTML="";
-    const box=h("div",{style:"border:1px solid #e2e8f0;padding:16px;border-radius:12px;max-width:520px"});
-    box.append(h("h3",{},BRAND+" — Member Perks"));
-    box.append(h("p",{},"Enter your membership email to view your monthly perks."));
-    const inp=h("input",{type:"email",placeholder:"email@example.com",style:"width:100%;padding:10px;border:1px solid #cbd5e1;border-radius:8px"});
-    const btn=h("button",{style:"margin-top:8px;padding:10px 14px;border-radius:8px;border:1px solid #1e293b;background:#1e293b;color:#fff"},"Show my perks");
-    btn.onclick=()=>{ email=inp.value.trim(); load(); };
-    box.append(inp,btn); el.append(box);
-  }
-  async function load(){
-    if(!email) return promptEmail();
-    el.innerHTML="Loading…";
-    try{
-      const r=await fetch(API+"/my-codes?email="+encodeURIComponent(email));
-      const j=await r.json();
-      if(j.reason==="inactive_membership"){ el.innerHTML="<p>Your membership is not active.</p>"; return; }
-      const codes=j.codes||[]; if(!codes.length){ el.innerHTML="<p>No available perks.</p>"; return; }
-      const grid=h("div",{style:"display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));"});
-      for(const c of codes){
-        const card=h("div",{style:"border:1px solid #e2e8f0;border-radius:12px;padding:16px"});
-        card.append(h("h4",{},c.benefit_label));
-        const canv=h("div",{style:"width:200px;height:200px;margin:auto"}); card.append(canv);
-        const badge=c.display_policy==="always_show"?"Valid all month":"Single-use";
-        card.append(h("p",{style:"font-size:12px;opacity:0.8;text-align:center;margin-top:8px"},badge));
-        const url=location.origin.replace(/\\/$/,'')+"/redeem?code="+encodeURIComponent(c.code);
-        try{
-          const m=await import("https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js");
-          const canvas=document.createElement("canvas"); canv.append(canvas);
-          await m.default.toCanvas(canvas, url, { width:200, margin:1 });
-        }catch(e){ canv.append(h("a",{href:url}, "Open redemption link")); }
-        grid.append(card);
-      }
-      el.innerHTML=""; el.append(grid);
-    }catch(e){ el.innerHTML="<p>Could not load perks.</p>"; }
-  }
-  load();
-})();`);
+  const js = await readFile(new URL("../public/widget.js", import.meta.url));
+  res.end(js);
 }
 
 function serveRedeemHTML(res) {

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,0 +1,52 @@
+(async function(){
+  const el = document.getElementById("member-qr-widget"); if (!el) return;
+  const s = document.currentScript;
+  const API = s.getAttribute("data-api") || (location.origin.replace(/\/$/,'') + "/api");
+  const BRAND = s.getAttribute("data-brand") || "Your Brand";
+  let email = s.getAttribute("data-email") || "";
+  const TOKEN = s.getAttribute("data-token") || "";
+
+  function h(tag, attrs={}, kids=[]) {
+    const e=document.createElement(tag);
+    Object.entries(attrs).forEach(([k,v])=> e.setAttribute(k,v));
+    (Array.isArray(kids)?kids:[kids]).forEach(c=> e.appendChild(typeof c==="string"?document.createTextNode(c):c));
+    return e;
+  }
+  function promptEmail(){ el.innerHTML="";
+    const box=h("div",{style:"border:1px solid #e2e8f0;padding:16px;border-radius:12px;max-width:520px"});
+    box.append(h("h3",{},BRAND+" — Member Perks"));
+    box.append(h("p",{},"Enter your membership email to view your monthly perks."));
+    const inp=h("input",{type:"email",placeholder:"email@example.com",style:"width:100%;padding:10px;border:1px solid #cbd5e1;border-radius:8px"});
+    const btn=h("button",{style:"margin-top:8px;padding:10px 14px;border-radius:8px;border:1px solid #1e293b;background:#1e293b;color:#fff"},"Show my perks");
+    btn.onclick=()=>{ email=inp.value.trim(); load(); };
+    box.append(inp,btn); el.append(box);
+  }
+  async function load(){
+    if(!email) return promptEmail();
+    el.innerHTML="Loading…";
+    try{
+      const headers = TOKEN ? { Authorization: 'Bearer ' + TOKEN } : {};
+      const r=await fetch(API+"/my-codes?email="+encodeURIComponent(email), { headers });
+      const j=await r.json();
+      if(j.reason==="inactive_membership"){ el.innerHTML="<p>Your membership is not active.</p>"; return; }
+      const codes=j.codes||[]; if(!codes.length){ el.innerHTML="<p>No available perks.</p>"; return; }
+      const grid=h("div",{style:"display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));"});
+      for(const c of codes){
+        const card=h("div",{style:"border:1px solid #e2e8f0;border-radius:12px;padding:16px"});
+        card.append(h("h4",{},c.benefit_label));
+        const canv=h("div",{style:"width:200px;height:200px;margin:auto"}); card.append(canv);
+        const badge=c.display_policy==="always_show"?"Valid all month":"Single-use";
+        card.append(h("p",{style:"font-size:12px;opacity:0.8;text-align:center;margin-top:8px"},badge));
+        const url=location.origin.replace(/\/$/,'')+"/redeem?code="+encodeURIComponent(c.code);
+        try{
+          const m=await import("https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js");
+          const canvas=document.createElement("canvas"); canv.append(canvas);
+          await m.default.toCanvas(canvas, url, { width:200, margin:1 });
+        }catch(e){ canv.append(h("a",{href:url}, "Open redemption link")); }
+        grid.append(card);
+      }
+      el.innerHTML=""; el.append(grid);
+    }catch(e){ el.innerHTML="<p>Could not load perks.</p>"; }
+  }
+  load();
+})();


### PR DESCRIPTION
## Summary
- enforce bearer token validation in `api/my-codes`
- update widget to forward token in Authorization header
- document token flow and widget usage

## Testing
- `node --check api/index.js`
- `node --check public/widget.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af3ba93e8c832fbd2baf9de9965126